### PR TITLE
Record memory usage.

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -42,7 +42,8 @@ class Analytics {
     data.properties = {
       total_orbit_stores: orbitStores,
       orbit_disk_usage: orbitDiskUsage,
-      ipfs_disk_usage: ipfsDiskUsage
+      ipfs_disk_usage: ipfsDiskUsage,
+      memory_usage: process.memoryUsage().rss / 1024 / 1024
     }
     this._track(data)
   }

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -43,7 +43,9 @@ class Analytics {
       total_orbit_stores: orbitStores,
       orbit_disk_usage: orbitDiskUsage,
       ipfs_disk_usage: ipfsDiskUsage,
-      memory_usage: process.memoryUsage().rss / 1024 / 1024
+      resident_memory_usage: process.memoryUsage().rss / 1024 / 1024,
+      heap_total_memory: process.memoryUsage().heapTotal / 1024 / 1024,
+      heap_used_memory: process.memoryUsage().heapUsed / 1024 / 1024
     }
     this._track(data)
   }


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/12023359/what-do-the-return-values-of-node-js-process-memoryusage-stand-for
Of all the data that `process.memoryUsage()` returns, only the `resident set size` (a.k.a total memory used by the process) seems to be relevant.