### PR TITLE
fix: openDB now only responds once per DB

### DIFF
--- a/src/pinning.js
+++ b/src/pinning.js
@@ -88,10 +88,11 @@ class Pinning {
         if (onReplicatedFn) onReplicatedFn(address)
       })
     } else {
-      if (this.openDBs[address].dbPromise) {
-        await this.openDBs[address].dbPromise
+      if (!this.openDBs[address].dbPromise) {
+        // We don't need to call the responseFn if there is a promise present
+        // as it will get called anyway
+        responseFn(address)
       }
-      responseFn(address)
     }
     tick.stop()
     this.analytics.trackOpenDB(address, timer.timers.openDB.duration())
@@ -104,7 +105,9 @@ class Pinning {
   }
 
   _openSubStores (address) {
-    this.openDBs[address].db.iterator({ limit: -1 }).collect().map(entry => {
+    const entries = this.openDBs[address].db.iterator({ limit: -1 }).collect()
+    const uniqueEntries = entries.filter((v, i, a) => a.indexOf(v) === i)
+    uniqueEntries.map(entry => {
       const odbAddress = entry.payload.value.odbAddress
       if (odbAddress) {
         this.openDB(odbAddress, this._sendHasResponse.bind(this))


### PR DESCRIPTION
In addition to waiting for the open promise to be resolved we now also wait for the db to be loaded before we send the `HAS_ENTRIES` event.

I think this actually fixes most of our issues 🎉 