### PR TITLE
fix(pinning): handle malformed PIN_DB messages

### DIFF
--- a/src/pinning.js
+++ b/src/pinning.js
@@ -133,7 +133,7 @@ class Pinning {
 
   _onMessage (topic, data) {
     console.log(topic, data)
-    if (!data.type || data.type === 'PIN_DB') {
+    if (data.type === 'PIN_DB' && OrbitDB.isValidAddress(data.odbAddress)) {
       this.openDB(data.odbAddress, this._openSubStoresAndSendHasResponse.bind(this), this._openSubStores.bind(this))
       this.cache.invalidate(data.odbAddress)
       this.analytics.trackPinDB(data.odbAddress)


### PR DESCRIPTION
Was looking to fix https://github.com/3box/3box-pinning-server/issues/57 but turns out it was already addressed. Instead I fixed an issue where if the `PIN_DB` msg does not contain a valid orbitdb address, the pinning module would throw an error.