### PR TITLE
feat(cache): More thoughtful invalidation of redis cache

### DIFF
--- a/src/__tests__/cache.test.js
+++ b/src/__tests__/cache.test.js
@@ -38,10 +38,7 @@ describe('RedisCache', () => {
   it('should write values correctly', async () => {
     await cache.invalidate('test')
 
-    expect(cache.redis.del).toHaveBeenCalledTimes(4)
-    expect(cache.redis.del).toHaveBeenNthCalledWith(1, 'space-list_test')
-    expect(cache.redis.del).toHaveBeenNthCalledWith(2, 'test')
-    expect(cache.redis.del).toHaveBeenNthCalledWith(3, 'test_s1')
-    expect(cache.redis.del).toHaveBeenNthCalledWith(4, 'test_s2')
+    expect(cache.redis.del).toHaveBeenCalledTimes(1)
+    expect(cache.redis.del).toHaveBeenCalledWith('test')
   })
 })

--- a/src/cache.js
+++ b/src/cache.js
@@ -28,14 +28,7 @@ class RedisCache {
   }
 
   async invalidate (key) {
-    const spaces = await this.read(`space-list_${key}`)
-    this.redis.del(`space-list_${key}`)
     this.redis.del(key)
-    if (spaces) {
-      spaces.map(space => {
-        this.redis.del(`${key}_${space}`)
-      })
-    }
   }
 }
 


### PR DESCRIPTION
This was simpler than I first expected 😄 

We now invalidate the cache individually for space-list, public store, and spaces. This is done when a DB is opened and when data has been replicated from a remote peer. 

There is a new method called `invalidateDBCache` which takes two parameters, first the address of the affected DB and then the rootStoreAddress. From these params it can figure out which store to invalidate. 